### PR TITLE
Allow for Consul UI w/o nginx install

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,22 @@ Here is a list of all the default variables for this role, which are also availa
 
 ```yml
 ---
-consul_version: 0.5.2
-consul_archive: "{{ consul_version }}_linux_amd64.zip"
-consul_download: "https://dl.bintray.com/mitchellh/consul/{{ consul_archive }}"
+consul_version: 0.6.0
+consul_archive: "consul_{{ consul_version }}_linux_amd64.zip"
+consul_download: "https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_archive }}"
 consul_download_username: ""
 consul_download_password: ""
 consul_download_folder: /tmp
 
 consul_is_ui: false
-consul_ui_archive: "{{ consul_version }}_web_ui.zip"
-consul_ui_download: "https://dl.bintray.com/mitchellh/consul/{{ consul_ui_archive }}"
+consul_ui_archive: "consul_{{ consul_version }}_web_ui.zip"
+consul_ui_download: "https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_ui_archive }}"
 consul_ui_dir: "{{ consul_home }}/dist"
 consul_ui_server_name: "{{ ansible_fqdn }}"
 consul_ui_require_auth: false
 consul_ui_auth_user_file: /etc/htpasswd/consul
+consul_install_nginx: true
+consul_install_nginx_config: true
 consul_enable_nginx_config: true
 
 consul_install_consul_cli: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-consul_version: 0.5.2
+consul_version: 0.6.0
 consul_archive: "consul_{{ consul_version }}_linux_amd64.zip"
 consul_download: "https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_archive }}"
 consul_download_username: ""
@@ -15,6 +15,8 @@ consul_ui_require_auth: false
 consul_ui_nginx_template: "consul-nginx.conf.j2"
 consul_ui_auth_user_file: /etc/htpasswd/consul
 consul_ui_server_port: 80
+consul_install_nginx: true
+consul_install_nginx_config: true
 consul_enable_nginx_config: true
 
 consul_install_consul_cli: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,6 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - { role: franklinkim.nginx, when: consul_is_ui == true and ansible_os_family == "Debian" }
-  - { role: geerlingguy.nginx, when: consul_is_ui == true and ansible_os_family == "RedHat" }
+  - { role: franklinkim.nginx, when: consul_install_nginx == true and ansible_os_family == "Debian" }
+  - { role: geerlingguy.nginx, when: consul_install_nginx == true and ansible_os_family == "RedHat" }
   - { role: joshualund.golang, when: consul_install_consul_cli == true }

--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -32,11 +32,11 @@
     owner=root
     group=root
     mode=0755
-  when: consul_is_ui and ansible_os_family == "Debian"
+  when: consul_install_nginx_config and ansible_os_family == "Debian"
   notify:
     - restart nginx
 
-- name: consul nginx config
+- name: consul nginx config enable
   file: >
     state=link
     src=/etc/nginx/sites-available/consul
@@ -55,7 +55,7 @@
     owner=root
     group=root
     mode=0755
-  when: consul_is_ui and ansible_os_family == "RedHat"
+  when: consul_is_ui and consul_install_nginx_config and ansible_os_family == "RedHat"
 
 - name: create nginx home
   file: >
@@ -66,4 +66,4 @@
     mode=0755
   notify:
     - restart nginx
-  when: consul_enable_nginx_config
+  when: consul_install_nginx_config and consul_enable_nginx_config


### PR DESCRIPTION
Added two new variables:
consul_install_nginx: true
consul_install_nginx_config: true

To allow for Consul UI install w/o nginx - I feel it's common for people to have their own roles for nginx and the fact that nginx is installed potentially conflicts with that and was a suprise for me as well. 

Also set to latest Consul version and updated README for that. 