### PR TITLE
Add CONSUL_RPC_ADDR env variable to .bashrc

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -164,3 +164,7 @@
     owner={{consul_user}}
     group={{consul_group}}
     mode=0755
+
+- name: add CONSUL_RPC_ADDR to .bashrc
+  sudo: false
+  lineinfile: dest=~/.bashrc insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"'


### PR DESCRIPTION
If we set rpc address to something other than 127.0.0.1, consul command requires --rpc-addr flag or CONSUL_RPC_ADDR env variable. 

This PR adds that env variable so that consul commands continue to work with custom rpc address. 