### PR TITLE
added verify_server_hostname parameter

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -2,6 +2,12 @@
   stat: path={{ consul_download_folder }}/{{ consul_ui_archive }}
   register: consul_archive_ui_stat
 
+- name: create consul_ui_dir if it does not exist
+  file:
+    path: "{{ consul_ui_dir }}"
+    state: directory
+    mode: 0755
+
 - name: download consul ui
   get_url: >
     url={{consul_ui_download}}

--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -12,7 +12,7 @@
 - name: copy and unpack ui
   unarchive: >
     src={{ consul_download_folder }}/{{ consul_ui_archive }}
-    dest={{ consul_home }}
+    dest={{ consul_ui_dir }}
     copy=no
   when: consul_ui_was_downloaded|changed
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,6 +40,7 @@
   group: >
     name={{consul_group}}
     state=present
+  register: consul_group_created
 
 - name: create consul user
   user: >
@@ -47,6 +48,7 @@
     name={{consul_user}}
     group={{consul_group}}
     system=yes
+  when: consul_group_created|changed
 
 - name: create consul directory
   file: >

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -66,6 +66,9 @@
   "verify_incoming": true,
   "verify_outgoing": true,
 {% endif %}
+{% if consul_is_server and consul_cert_file is defined and consul_key_file is defined and consul_ca_file is defined and consul_server_hostname %}
+  "verify_server_hostname": true,
+{% endif %}
 {% if consul_is_server == false and consul_cert_file is defined and consul_key_file is defined and consul_ca_file is defined %}
   "cert_file": "{{ consul_cert_file }}",
   "key_file": "{{ consul_key_file }}",


### PR DESCRIPTION
Added verify_server_hostname parameter.

"Previously, a compromised client could be restarted as a server and perform a MITM attack against the cluster. With this PR, TLS certs can be generated matching the pattern of 'server'"

https://github.com/hashicorp/consul/issues/792