### PR TITLE
Fix systemd logging

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -52,3 +52,4 @@ suites:
   - name: tls
   - name: tls_client
   - name: ui
+  - name: logs

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -63,6 +63,28 @@
     - "{{ consul_data_dir }}"
     - "{{ consul_config_dir }}"
 
+# Check before creating log dir to prevent aggressively overwriting permissions
+- name: check for consul log directory
+  stat: >
+    path={{ consul_log_file|dirname }}
+  register: logdir
+
+- name: create log directory if it does not exist
+  file: >
+    state=directory
+    path={{ consul_log_file|dirname }}
+    owner={{ consul_user }}
+    group={{ consul_group }}
+  when: not logdir.stat.exists
+
+- name: touch the log file
+  file: >
+    state=touch
+    path={{ consul_log_file }}
+    owner={{ consul_user }}
+    group={{ consul_group }}
+  changed_when: false
+
 - name: copy and unpack
   unarchive: >
     src={{ consul_download_folder }}/{{ consul_archive }}

--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -5,7 +5,7 @@ Description=Consul Agent
 Environment="GOMAXPROCS=`nproc`"
 User={{ consul_user }}
 Group={{ consul_group }}
-ExecStart={{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }} >> {{ consul_log_file }} 2>&1
+ExecStart=/bin/sh -c '{{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }} >> {{ consul_log_file }} 2>&1'
 
 [Install]
 WantedBy=multi-user.target

--- a/test/integration/default/serverspec/consul_spec.rb
+++ b/test/integration/default/serverspec/consul_spec.rb
@@ -31,6 +31,11 @@ describe 'Consul' do
 
     describe file('/var/log/consul') do
       it { should be_file }
+      it { should be_owned_by('consul') }
+    end
+
+    describe file('/var/log') do
+      it { should_not be_owned_by('consul') }
     end
   end
 end

--- a/test/integration/logs/default.yml
+++ b/test/integration/logs/default.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+
+  roles:
+      - { role: ansible-consul, consul_log_file: /var/log/consul/consul.log, consul_is_server: true }

--- a/test/integration/logs/serverspec/consul_spec.rb
+++ b/test/integration/logs/serverspec/consul_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'Consul' do
+  describe service('consul') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe file('/var/log/consul') do
+    it { should be_directory }
+    it { should be_owned_by('consul') }
+  end
+
+  describe file('/var/log/consul/consul.log') do
+    it { should be_file }
+    it { should be_owned_by('consul') }
+    its(:size) { should > 0 }
+  end
+end

--- a/test/integration/logs/serverspec/spec_helper.rb
+++ b/test/integration/logs/serverspec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'serverspec'
+set :backend, :exec


### PR DESCRIPTION
The `ExecStart` value is executed as a command, not a shell, so we must
pass the command to `/bin/sh -c` in order to properly redirect output
to a logfile.

This also adds a serverspec test to verify log and log directory
permissions as well as that the log size is > 0, which presumably
means that the consul server is actually writing there.