### PR TITLE
Fix issues with test kitchen builds

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,6 +28,7 @@ platforms:
         consul_use_initd: true
         consul_use_systemd: false
         consul_use_upstart: false
+        nginx_user: nginx
     driver_config:
       box: puppetlabs/centos-6.6-64-nocm
 
@@ -38,6 +39,7 @@ platforms:
       require_ruby_for_busser: false
       extra_vars:
         consul_use_systemd: true
+        nginx_user: nginx
     driver_config:
       box: puppetlabs/centos-7.0-64-nocm
 

--- a/test/integration/helpers/serverspec/Gemfile
+++ b/test/integration/helpers/serverspec/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'net-ssh', '< 2.10'


### PR DESCRIPTION
 - Add a Gemfile to pin the version for net-ssh to < 2.10
   - Versions of net-ssh > 2.10 require Ruby 2.x, which causes most
     of the existing builds to break. See
     test-kitchen/busser-serverspec#37
 - Add `nginx_user` to default vars for CentOS builds
   - When both nginx roles are included, the variable for `nginx_user`
     is carried over from the Debian role which causes the builds
     on CentOS to try using the user `www-data`

Here's the output of a test run from master using `kitchen test default-centos7`. You'll see that tasks are run from both nginx roles, and the RHEL one (geerlingguy.nginx) fails because the nginx user is `www-data`.

```
       PLAY [localhost] ************************************************************** 
       
       GATHERING FACTS *************************************************************** 
       <localhost> REMOTE_MODULE setup
       <localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1452976365.35-24663856632162 && echo $HOME/.ansible/tmp/ansible-tmp-1452976365.35-24663856632162']
       <localhost> PUT /tmp/tmphDRMH7 TO /root/.ansible/tmp/ansible-tmp-1452976365.35-24663856632162/setup
       <localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1452976365.35-24663856632162/setup; rm -rf /root/.ansible/tmp/ansible-tmp-1452976365.35-24663856632162/ >/dev/null 2>&1']
       ok: [localhost]
       
       TASK: [franklinkim.nginx | Adding APT repository] ***************************** 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Installing packages] ******************************* 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Configuring nginx] ********************************* 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Disabling default site] **************************** 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Removing default host] ***************************** 
       skipping: [localhost] => (item=/etc/nginx/sites-available/default)
       skipping: [localhost] => (item=/var/www/html)
       
       TASK: [franklinkim.nginx | Adding rules] ************************************** 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Creating webroots] ********************************* 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Configuring sites] ********************************* 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Enabling sites] ************************************ 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Disabling sites] *********************************** 
       skipping: [localhost]
       
       TASK: [franklinkim.nginx | Configuring service] ******************************* 
       skipping: [localhost]
       
       TASK: [geerlingguy.nginx | Include OS-specific variables.] ******************** 
       ok: [localhost] => {"ansible_facts": {"__nginx_user": "nginx", "nginx_conf_path": "/etc/nginx/conf.d", "nginx_default_vhost_path": "/etc/nginx/conf.d/default.conf", "nginx_vhost_path": "/etc/nginx/conf.d"}}
       
       TASK: [geerlingguy.nginx | Define nginx_user.] ******************************** 
       skipping: [localhost]
       
       TASK: [geerlingguy.nginx | Enable nginx repo.] ******************************** 
       <localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1452976366.85-263789504269150 && echo $HOME/.ansible/tmp/ansible-tmp-1452976366.85-263789504269150']
       <localhost> EXEC ['/bin/sh', '-c', 'rc=flag; [ -r /etc/yum.repos.d/nginx.repo ] || rc=2; [ -f /etc/yum.repos.d/nginx.repo ] || rc=1; [ -d /etc/yum.repos.d/nginx.repo ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc} "/etc/yum.repos.d/nginx.repo && exit 0; (python -c \'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();\nafile = open("\'/etc/yum.repos.d/nginx.repo\'", "rb")\nbuf = afile.read(BLOCKSIZE)\nwhile len(buf) > 0:\n\thasher.update(buf)\n\tbuf = afile.read(BLOCKSIZE)\nafile.close()\nprint(hasher.hexdigest())\' 2>/dev/null) || (python -c \'import sha; BLOCKSIZE = 65536; hasher = sha.sha();\nafile = open("\'/etc/yum.repos.d/nginx.repo\'", "rb")\nbuf = afile.read(BLOCKSIZE)\nwhile len(buf) > 0:\n\thasher.update(buf)\n\tbuf = afile.read(BLOCKSIZE)\nafile.close()\nprint(hasher.hexdigest())\' 2>/dev/null) || (echo \'0 \'/etc/yum.repos.d/nginx.repo)']
       <localhost> PUT /tmp/tmp3Jl9YJ TO /root/.ansible/tmp/ansible-tmp-1452976366.85-263789504269150/source
       <localhost> PUT /tmp/tmphdM9wE TO /root/.ansible/tmp/ansible-tmp-1452976366.85-263789504269150/copy
       <localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1452976366.85-263789504269150/copy; rm -rf /root/.ansible/tmp/ansible-tmp-1452976366.85-263789504269150/ >/dev/null 2>&1']
       changed: [localhost] => {"changed": true, "checksum": "bff0bd4df6b8bccfb86c1b03fc1f1bc93fb7a0f2", "dest": "/etc/yum.repos.d/nginx.repo", "gid": 0, "group": "root", "md5sum": "c8473d7b3b6920ac8d59ac3ae6e843e0", "mode": "0644", "owner": "root", "size": 99, "src": "/root/.ansible/tmp/ansible-tmp-1452976366.85-263789504269150/source", "state": "file", "uid": 0}
       
       TASK: [geerlingguy.nginx | Ensure nginx is installed.] ************************ 
       <localhost> REMOTE_MODULE yum pkg=nginx state=installed enablerepo=nginx
       <localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1452976366.99-133687702467323 && echo $HOME/.ansible/tmp/ansible-tmp-1452976366.99-133687702467323']
       <localhost> PUT /tmp/tmpn7MmtZ TO /root/.ansible/tmp/ansible-tmp-1452976366.99-133687702467323/yum
       <localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python -tt /root/.ansible/tmp/ansible-tmp-1452976366.99-133687702467323/yum; rm -rf /root/.ansible/tmp/ansible-tmp-1452976366.99-133687702467323/ >/dev/null 2>&1']
       changed: [localhost] => {"changed": true, "msg": "", "rc": 0, "results": ["Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\n * base: dallas.tx.mirror.xygenhosting.com\n * epel: mirror.oss.ou.edu\n * extras: mirror.raystedman.net\n * updates: mirror.cogentco.com\nResolving Dependencies\n--> Running transaction check\n---> Package nginx.x86_64 1:1.8.0-1.el7.ngx will be installed\n--> Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package        Arch            Version                    Repository      Size\n================================================================================\nInstalling:\n nginx          x86_64          1:1.8.0-1.el7.ngx          nginx          369 k\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal download size: 369 k\nInstalled size: 889 k\nDownloading packages:\nRunning transaction check\nRunning transaction test\nTransaction test succeeded\nRunning transaction\n  Installing : 1:nginx-1.8.0-1.el7.ngx.x86_64                               1/1 \n----------------------------------------------------------------------\n\nThanks for using nginx!\n\nPlease find the official documentation for nginx here:\n* http://nginx.org/en/docs/\n\nCommercial subscriptions for nginx are available on:\n* http://nginx.com/products/\n\n----------------------------------------------------------------------\n  Verifying  : 1:nginx-1.8.0-1.el7.ngx.x86_64                               1/1 \n\nInstalled:\n  nginx.x86_64 1:1.8.0-1.el7.ngx                                                \n\nComplete!\n"]}
       
       TASK: [geerlingguy.nginx | Update apt cache.] ********************************* 
       skipping: [localhost]
       
       TASK: [geerlingguy.nginx | Ensure nginx is installed.] ************************ 
       skipping: [localhost]
       
       TASK: [geerlingguy.nginx | Remove default nginx vhost config file (if configured).] *** 
       skipping: [localhost]
       
       TASK: [geerlingguy.nginx | Add managed vhost config file (if any vhosts are configured).] *** 
       skipping: [localhost]
       
       TASK: [geerlingguy.nginx | Remove managed vhost config file (if no vhosts are configured).] *** 
       <localhost> REMOTE_MODULE file state=absent path=/etc/nginx/conf.d/vhosts.conf
       <localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1452976377.21-93613928734408 && echo $HOME/.ansible/tmp/ansible-tmp-1452976377.21-93613928734408']
       <localhost> PUT /tmp/tmpiL6l8u TO /root/.ansible/tmp/ansible-tmp-1452976377.21-93613928734408/file
       <localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1452976377.21-93613928734408/file; rm -rf /root/.ansible/tmp/ansible-tmp-1452976377.21-93613928734408/ >/dev/null 2>&1']
       ok: [localhost] => {"changed": false, "path": "/etc/nginx/conf.d/vhosts.conf", "state": "absent"}
       
       TASK: [geerlingguy.nginx | Copy nginx configuration in place.] **************** 
       <localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674 && echo $HOME/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674']
       <localhost> EXEC ['/bin/sh', '-c', 'rc=flag; [ -r /etc/nginx/nginx.conf ] || rc=2; [ -f /etc/nginx/nginx.conf ] || rc=1; [ -d /etc/nginx/nginx.conf ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc} "/etc/nginx/nginx.conf && exit 0; (python -c \'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();\nafile = open("\'/etc/nginx/nginx.conf\'", "rb")\nbuf = afile.read(BLOCKSIZE)\nwhile len(buf) > 0:\n\thasher.update(buf)\n\tbuf = afile.read(BLOCKSIZE)\nafile.close()\nprint(hasher.hexdigest())\' 2>/dev/null) || (python -c \'import sha; BLOCKSIZE = 65536; hasher = sha.sha();\nafile = open("\'/etc/nginx/nginx.conf\'", "rb")\nbuf = afile.read(BLOCKSIZE)\nwhile len(buf) > 0:\n\thasher.update(buf)\n\tbuf = afile.read(BLOCKSIZE)\nafile.close()\nprint(hasher.hexdigest())\' 2>/dev/null) || (echo \'0 \'/etc/nginx/nginx.conf)']
       <localhost> PUT /tmp/tmp9v_wUn TO /root/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674/source
       <localhost> PUT /tmp/tmpnK7bwA TO /root/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674/copy
       <localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674/copy; rm -rf /root/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674/ >/dev/null 2>&1']
       failed: [localhost] => {"failed": true}
       msg: failed to validate: rc:1 error:nginx: [emerg] getpwnam("www-data") failed in /root/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674/source:1
       nginx: configuration file /root/.ansible/tmp/ansible-tmp-1452976377.3-211663698934674/source test failed
       
       
       FATAL: all hosts have already failed -- aborting
       
       PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/root/default.retry
       
       localhost                  : ok=6    changed=2    unreachable=0    failed=1   
       
>>>>>> Converge failed on instance <default-centos7>.
>>>>>> Please see .kitchen/logs/default-centos7.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: SSH exited (2) for command: [sudo -E ansible-playbook --inventory-file=/tmp/kitchen/hosts -c local -M /tmp/kitchen/modules -vvv    -e '{"consul_use_systemd":true}'   /tmp/kitchen/default.yml]
>>>>>> ----------------------

```