### PR TITLE
Fix nginx root

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -65,14 +65,3 @@
     group=root
     mode=0755
   when: consul_is_ui and consul_install_nginx_config and ansible_os_family == "RedHat"
-
-- name: create nginx home
-  file: >
-    state=directory
-    path=/var/www/consul/htdocs
-    owner=root
-    group=root
-    mode=0755
-  notify:
-    - restart nginx
-  when: consul_install_nginx_config and consul_enable_nginx_config

--- a/templates/consul-nginx.conf.j2
+++ b/templates/consul-nginx.conf.j2
@@ -1,6 +1,6 @@
 server {
   server_name {{ consul_ui_server_name }};
-  root /var/www/consul/htdocs;
+  root {{ consul_ui_dir }};
 
   # --- listen ----------------------------------------------------------------
 


### PR DESCRIPTION
I had to make these changes for the consul ui to be immediately available after the ansible run finished. here are the variables I'm using for all three local consul nodes i'm using for testing:
```
consul_version: 0.6.3
consul_is_server: true
consul_servers:
  - 192.168.13.6
  - 192.168.13.7
  - 192.168.13.8
consul_datacenter: local
consul_syslog: true
consul_bind_address: "{{ansible_ssh_host}}"
consul_advertise_address: "{{ansible_ssh_host}}"
consul_bootstrap_expect: 3
consul_join_at_start: true
consul_retry_join: true
```

and specifically on the node that is running to ui:
```
consul_is_ui: true
consul_ui_server_name: consul1.dev
```

and my inventory:
```
[consul]
consul1 ansible_ssh_host=192.168.13.6
consul2 ansible_ssh_host=192.168.13.7
consul3 ansible_ssh_host=192.168.13.8
```

i'm curious to hear if i'm doing something wrong with the static path: `/var/www/consul/htdocs` or if it is left over from a time before `{{ consul_ui_dir }}`