### PR TITLE
Fix config for start_join_wan

### DIFF
--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -11,7 +11,7 @@
   "retry_max": {{ consul_retry_max }},
 {% endif %}
 {% if consul_join_wan|default(false) %}
-  "join_wan": [{% for host in consul_servers_wan | difference(ansible_all_ipv4_addresses) %}"{{host}}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "start_join_wan": [{% for host in consul_servers_wan | difference(ansible_all_ipv4_addresses) %}"{{host}}"{% if not loop.last %}, {% endif %}{% endfor %}],
 {% endif %}
 {% if consul_retry_join_wan|default(false) %}
   "retry_join_wan": [{% for host in consul_servers_wan | difference(ansible_all_ipv4_addresses) %}"{{host}}"{% if not loop.last %}, {% endif %}{% endfor %}],


### PR DESCRIPTION
In a previous commit, I mistakenly used the key `join_wan` instead of `start_join_wan`. I overlooked this because I was using the `retry_join_wan` option in my testing.