### PR TITLE
New variable for verify_server_hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ consul_install_dnsmasq: false
 consul_install_consulate: false
 
 consul_node_name: "{{ inventory_hostname }}"
+consul_verify_server_hostname: false
 ```
 
 An instance might be defined through:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,3 +91,5 @@ consul_install_dnsmasq: false
 consul_install_consulate: false
 
 consul_node_name: "{{ inventory_hostname }}"
+# Set to true to enable hostname verification via TLS
+consul_verify_server_hostname: false

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -81,9 +81,7 @@
   "ca_file": "{{ consul_ca_file }}",
   "verify_incoming": true,
   "verify_outgoing": true,
-{% endif %}
-{% if consul_is_server and consul_cert_file is defined and consul_key_file is defined and consul_ca_file is defined and consul_server_hostname %}
-  "verify_server_hostname": true,
+  "verify_server_hostname": {{ consul_verify_server_hostname|lower }},
 {% endif %}
 {% if consul_is_server == false and consul_cert_file is defined and consul_key_file is defined and consul_ca_file is defined %}
   "cert_file": "{{ consul_cert_file }}",


### PR DESCRIPTION
Replace the `consul_server_hostname` variable with
`consul_verify_server_hostname`. `consul_server_hostname` can be misleading,
and matching the config setting name is a good convention.

Duplicated logic in the Consul template has also been reduced by including this
option in the same block as the other TLS options.