### PR TITLE
Do not restart Consul every time

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -188,6 +188,8 @@
     owner={{consul_user}}
     group={{consul_group}}
     mode=0755
+  notify:
+    - restart consul
 
 - name: add CONSUL_RPC_ADDR to .bashrc
   sudo: false

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,3 +1,4 @@
 - service: >
     name=consul
-    state=restarted
+    state=started
+    enabled=yes


### PR DESCRIPTION
`tasks/service.yml` was restarting the Consul service every time
it ran, regardless of whether or not there were changes. This
is less than optimal, especially on a production system.

Instead, ensure the service is started, and only notify a restart
when the configuration changes.