### PR TITLE
Bump default consul version from 0.6.0 to 0.6.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-consul_version: 0.6.0
+consul_version: 0.6.3
 consul_archive: "consul_{{ consul_version }}_linux_amd64.zip"
 consul_download: "https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_archive }}"
 consul_download_username: ""


### PR DESCRIPTION
0.6.3 is the latest as of today (2016-02-21).