### PR TITLE
Change the way we manage UI depending on consul version.

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -7,16 +7,18 @@
     path: "{{ consul_ui_dir }}"
     state: directory
     mode: 0755
+  when: consul_version | version_compare('0.6.1', '<')
 
 - name: download consul ui
   get_url: >
     url={{consul_ui_download}}
     dest={{consul_download_folder}}
   register: consul_ui_was_downloaded
-  when: consul_archive_ui_stat.stat.exists == False
+  when: consul_version | version_compare('0.6.1', '<') and consul_archive_ui_stat.stat.exists == False
 
 - name: create ui dir
   file: path={{ consul_ui_dir }} state=directory
+  when: consul_version | version_compare('0.6.1', '<')
 
 - name: copy and unpack ui
   unarchive: >

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -1,6 +1,10 @@
 {
 {% if consul_is_ui == true %}
-  "ui_dir": "{{ consul_ui_dir }}",
+  {% if consul_version | version_compare('0.6.1', '<') %}
+    "ui_dir": "{{ consul_ui_dir }}",
+  {% else %}
+    "ui": true,
+  {% endif %}
 {% endif %}
 {% if consul_join_at_start is defined and consul_join_at_start %}
   "start_join": [{% for host in consul_servers | difference(ansible_all_ipv4_addresses) %}"{{host}}"{% if not loop.last %}, {% endif %}{% endfor %}],


### PR DESCRIPTION
This patch is a proposed fix for #112.
- No need to download and install the ui package
- Need to start the agent with -ui (ui: true in config) instead of ui-dir

It checks on the 6.0.1 version because that is when the ui parameter was introduced in Consul.