### PR TITLE
Better systemd support.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -146,9 +146,9 @@
   template: >
     src={{consul_systemd_template}}
     dest=/etc/systemd/system/consul.service
-    owner={{consul_user}}
-    group={{consul_group}}
-    mode=0755
+    owner=root
+    group=root
+    mode=0644
   when: consul_use_systemd
   notify:
     - reload systemd

--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -1,5 +1,7 @@
 [Unit]
 Description=Consul Agent
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Environment="GOMAXPROCS=`nproc`"


### PR DESCRIPTION
Consul need network online before starting or it would fail.
By the way, there is no reason the service file is 755, and it should be owned by root.
The same asumption could be made (owned by root) for the syvinit script (I can't see no reason to have it owned by the consul user), but I didn't change it because this patch is focused on systemd.