### PR TITLE
Add requirements on EPEL repos.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
   categories:
     - system
 dependencies:
+  - { role: geerlingguy.repo-epel, when: ansible_os_family == "RedHat" }
   - { role: franklinkim.nginx, when: consul_install_nginx == true and ansible_os_family == "Debian" }
   - { role: geerlingguy.nginx, when: consul_install_nginx == true and ansible_os_family == "RedHat" }
   - { role: joshualund.golang, when: consul_install_consul_cli == true }

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
+- src: geerlingguy.repo-epel
 - src: franklinkim.nginx
 - src: geerlingguy.nginx
 - src: joshualund.golang


### PR DESCRIPTION
The install task needs to install jq, which is not present in the default yum repos.
So this patch add a dependency on the geerlingguy.repo-epel for RedHat family.