### PR TITLE
Configure selinux to allow nginx to contact other servers (consul).

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -66,6 +66,10 @@
     mode=0755
   when: consul_is_ui and consul_install_nginx_config and ansible_os_family == "RedHat"
 
+- name: allow nginx to connect to consul (selinux)
+  seboolean: name=httpd_can_network_connect state=yes persistent=yes
+  when: consul_is_ui and consul_install_nginx_config and ansible_selinux.status == "enabled"  
+
 - name: create nginx home
   file: >
     state=directory


### PR DESCRIPTION
With this change, nginx is allowed to contact the consul service even in enforcing mode.