### PR TITLE
Set RPC_ADDR in the consul users bashrc

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -193,4 +193,4 @@
 
 - name: add CONSUL_RPC_ADDR to .bashrc
   sudo: false
-  lineinfile: dest=~/.bashrc insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"'
+  lineinfile: dest="/home/{{ consul_user }}/.bashrc" insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"'


### PR DESCRIPTION
Previous task was trying to set the CONSUL_RPC_ADDR in the user executing ansible bashrc file. Set this in the consul user's bashrc instead.