### PR TITLE
sudo/sudo_user > become/become_user

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,11 +3,11 @@
   action: service name=consul state=restarted enabled=yes
 
 - name: reload consul config
-  sudo: yes
+  become: yes
   command: pkill -1 consul
 
 - name: reload systemd
-  sudo: yes
+  become: yes
   command: systemctl daemon-reload
 
 - name: restart dnsmasq

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -192,5 +192,6 @@
     - restart consul
 
 - name: add CONSUL_RPC_ADDR to .bashrc
-  sudo: false
-  lineinfile: dest="/home/{{ consul_user }}/.bashrc" insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"'
+  become: yes
+  become_user: "{{ consul_user }}"
+  lineinfile: dest="{{ consul_home }}/.bashrc" insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"'


### PR DESCRIPTION
I keep getting this message:
```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make 
sure become_method is 'sudo' (default). This feature will be removed in a future 
release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```
I fixed it.