### PR TITLE
Create the bashrc file if it doesn't already exist

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -192,4 +192,4 @@
     - restart consul
 
 - name: add CONSUL_RPC_ADDR to .bashrc
-  lineinfile: dest="{{ consul_home }}/.bashrc" insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"'
+  lineinfile: dest="{{ consul_home }}/.bashrc" insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"' create=yes


### PR DESCRIPTION
Ensure the role creates a bashrc file in  `consul_home` if it doesn't exist