### PR TITLE
Allow consul service state to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ consul_ui_server_port: 80
 consul_install_nginx: true
 consul_install_nginx_config: true
 consul_enable_nginx_config: true
+consul_service_state: restarted
 
 consul_install_consul_cli: false
 consul_cli_archive: "master.zip"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ consul_install_nginx: true
 consul_install_nginx_config: true
 consul_enable_nginx_config: true
 consul_service_state: restarted
+consul_manage_service: true
 
 consul_install_consul_cli: false
 consul_cli_archive: "master.zip"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ consul_ui_server_port: 80
 consul_install_nginx: true
 consul_install_nginx_config: true
 consul_enable_nginx_config: true
+consul_service_state: restarted
 
 consul_install_consul_cli: false
 consul_cli_archive: "master.zip"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,12 @@
 ---
 - name: restart consul
   action: service name=consul state={{ consul_service_state }} enabled=yes
+  when: consul_manage_service
 
 - name: reload consul config
   sudo: yes
   command: pkill -1 consul
-  when: consul_service_state is not  "stopped"
+  when: consul_service_state is not "stopped" and consul_manage_service
 
 - name: reload systemd
   sudo: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,11 @@
 ---
 - name: restart consul
-  action: service name=consul state=restarted enabled=yes
+  action: service name=consul state={{ consul_service_state }} enabled=yes
 
 - name: reload consul config
   sudo: yes
   command: pkill -1 consul
+  when: consul_service_state is not  "stopped"
 
 - name: reload systemd
   sudo: yes

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,4 @@
 - service: >
     name=consul
-    state=started
+    state="{{ consul_service_state }}"
     enabled=yes


### PR DESCRIPTION
In order to allow playbooks to decide what state to leave the consul service in, the handler needs to accept a parameter for `consul_service_state`. 