### PR TITLE
Update init.d mode to 755

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -160,7 +160,7 @@
     dest=/etc/init.d/consul
     owner=root
     group=root
-    mode=0644
+    mode=0755
   when: consul_use_initd
   notify:
     - restart consul


### PR DESCRIPTION
The mode for the init.d script was 0644, which meant the service start
would fail.  Update the script to be executable.

(platform was Amazon Linux, but any initd system should be similar)