### PR TITLE
removing shell redirection

### DIFF
--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -8,7 +8,7 @@ Environment="GOMAXPROCS=`nproc`"
 Restart=on-failure
 User={{ consul_user }}
 Group={{ consul_group }}
-ExecStart=/bin/sh -c '{{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }} >> {{ consul_log_file }} 2>&1'
+ExecStart=/bin/sh -c '{{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}'
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 


### PR DESCRIPTION
Systemd automatically logs stdout/error to syslog, so it's a bit redundant to create a separate log file.

https://www.freedesktop.org/software/systemd/man/systemd.exec.html

