### PR TITLE
Reorder handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ consul_retry_join_wan: false
 consul_retry_interval_wan: 30s
 consul_retry_max_wan: 0
 consul_advertise_address_wan: false
-
+consul_advertise_address: "127.0.0.1" - default: `undefined`. If this variable is not defined it is not set in the config
 consul_bind_address: "0.0.0.0"
 consul_dynamic_bind: false
 consul_client_address: "127.0.0.1"

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ See [https://www.consul.io/docs/agent/encryption.html](https://www.consul.io/doc
 These files will be created on your Consul host:
 
 ```yml
-consul_cert_file: "{{ consul_home }}/cert/consul.crt",
-consul_key_file: "{{ consul_home }}/cert/consul.key",
-consul_ca_file: "{{ consul_home }}/cert/ca.crt",
+consul_cert_file: "{{ consul_home }}/cert/consul.crt"
+consul_key_file: "{{ consul_home }}/cert/consul.key"
+consul_ca_file: "{{ consul_home }}/cert/ca.crt"
 ```
 
 When you provide these vars. You should use Ansible Vault to encrypt these vars or perhaps pass them on the command line.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ Consul allows adding headers to the HTTP API responses, to enable [CORS](https:/
 ```yml
 consul_cors_support: true
 ```
+## Shutdown behavior
+Consul may be configured to perform (or not) cluster leave when it recieves TERM/INT signals.
+
+When service is stopped:
+ * systemd sends INT
+ * init (init.d script) sends TERM
+ * upstart sends TERM
+
+There are two variables that define if the node will attempt cluster leave when it recieves those signals:
+
+ * `consul_leave_on_terminate` defines if leave is performed when TERM is recieved. default: `false`
+ * `consul_skip_leave_on_interrupt` defines if leave is **not** performed when INT is recieved. default: `undefined`. If this variable is not defined default consul behavior (which depends on version and server/agent role) will be used.
 
 ## Handlers
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ consul_dnsmasq:
 consul_node_name: "{{ inventory_hostname }}"
 consul_verify_server_hostname: false
 consul_cors_support: false
+disable_update_check: false
 ```
 
 An instance might be defined through:

--- a/README.md
+++ b/README.md
@@ -272,6 +272,25 @@ These are the handlers that are defined in `handlers/main.yml`.
     - ansible-consul
 ```
 
+## Example playbook that configures a Consul server on Ubuntu with [runit](https://github.com/gitinsky/ansible-role-runit)
+```yml
+- hosts: all
+  vars:
+    consul_reload_config_handler: runit reload consul
+    consul_restart_handler: runit restart consul
+    consul_log_file: /dev/null
+  roles:
+    - ansible-consul
+    - role: runit
+      runit_pre_start_command: "setcap CAP_NET_BIND_SERVICE=+eip /opt/consul/bin/consul"
+      runit_service_command: "/opt/consul/bin/consul"
+      runit_service_params: "agent -config-dir /etc/consul.d -config-file=/etc/consul.conf"
+      runit_service_env:
+        GOMAXPROCS: "{{ ansible_processor_vcpus }}"
+```
+
+Logs will be handled by runit and ```consul_log_file``` set to ```/dev/null``` just to prevent ```/var/log/consul``` file creation as it conflicts with runit logs directory.
+
 ## Example playbooks that configures a Consul server on CentOS 7
 
 ```yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ consul_ui_server_port: 80
 consul_install_nginx: true
 consul_install_nginx_config: true
 consul_enable_nginx_config: true
-consul_service_state: restarted
+consul_service_state: started
 consul_manage_service: true
 
 consul_install_consul_cli: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,3 +112,5 @@ consul_node_name: "{{ inventory_hostname }}"
 # Set to true to enable hostname verification via TLS
 consul_verify_server_hostname: false
 consul_cors_support: false
+# keep undefined for default behavior (will depend on agent/server role starting with consul 0.7)
+# consul_skip_leave_on_interrupt: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,9 @@ consul_kv_template: "consulkv.j2"
 consul_add_path_template: "consul.sh.j2"
 consul_config_template: "consul.json.j2"
 
+consul_reload_config_handler: reload consul config
+consul_restart_handler: restart consul
+
 consul_binary: consul
 
 consul_user: consul

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -114,3 +114,4 @@ consul_verify_server_hostname: false
 consul_cors_support: false
 # keep undefined for default behavior (will depend on agent/server role starting with consul 0.7)
 # consul_skip_leave_on_interrupt: false
+disable_update_check: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -117,4 +117,4 @@ consul_verify_server_hostname: false
 consul_cors_support: false
 # keep undefined for default behavior (will depend on agent/server role starting with consul 0.7)
 # consul_skip_leave_on_interrupt: false
-disable_update_check: false
+consul_disable_update_check: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart consul
-  action: service name=consul state={{ consul_service_state }} enabled=yes
+  action: service name=consul state=restarted enabled=yes
   when: consul_manage_service
 
 - name: reload consul config

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,12 +4,12 @@
   when: consul_manage_service
 
 - name: reload consul config
-  sudo: yes
+  become: yes
   command: pkill -1 consul
   when: consul_service_state is not "stopped" and consul_manage_service
 
 - name: reload systemd
-  sudo: yes
+  become: yes
   command: systemctl daemon-reload
 
 - name: restart dnsmasq

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: reload systemd
+  become: yes
+  command: systemctl daemon-reload
+
 - name: restart consul
   action: service name=consul state=restarted enabled=yes
   when: consul_manage_service
@@ -7,10 +12,6 @@
   become: yes
   command: pkill -1 consul
   when: consul_service_state is not "stopped" and consul_manage_service
-
-- name: reload systemd
-  become: yes
-  command: systemctl daemon-reload
 
 - name: restart dnsmasq
   service: name=dnsmasq state=restarted enabled=yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,17 +2,25 @@
 galaxy_info:
   author: Matthew Finlayson
   description: Installs and configures consul
-  company: Jive Software
+  license: Apache
   platforms:
     - name: Ubuntu
       versions:
-        - All
+        - 12.04
+        - 14.04
+        - 15.10
+        - 16.04
     - name: EL
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - system
+    - cloud
+    - clustering
+    - networking
+    - web
+  min_ansible_version: 1.2
 dependencies:
   - { role: geerlingguy.repo-epel, when: ansible_os_family == "RedHat" }
   - { role: franklinkim.nginx, when: consul_install_nginx == true and ansible_os_family == "Debian" }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,10 +6,10 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - 12.04
-        - 14.04
-        - 15.10
-        - 16.04
+        - precise
+        - trusty
+        - wily
+        - xenial
     - name: EL
       versions:
         - 6

--- a/tasks/install-cli.yml
+++ b/tasks/install-cli.yml
@@ -1,19 +1,23 @@
-- name: delete the consul-cli build directory
-  file:
-    path: "{{ consul_download_folder }}/consul-cli-master"
-    state: absent
 
 - name: download consul-cli source archive
   get_url:
     url: "{{ consul_cli_download }}"
     dest: "{{ consul_download_folder }}/{{ consul_cli_archive }}"
     force: yes
+  register: cli_download
+
+- name: delete the consul-cli build directory
+  file:
+    path: "{{ consul_download_folder }}/consul-cli-master"
+    state: absent
+  when: cli_download.changed
 
 - name: Unarchive consul-cli source
   unarchive:
     src: "{{ consul_download_folder }}/{{ consul_cli_archive }}"
     dest: "{{ consul_download_folder }}"
     copy: no
+  when: cli_download.changed
 
 - name: build consul-cli source code
   shell: make
@@ -23,11 +27,13 @@
   environment:
     PATH: "/usr/local/go/bin:{{ ansible_env.PATH }}"
     GOPATH: "{{ ansible_env.HOME }}/go"
+  when: cli_download.changed
 
 - name: copy consul-cli to the bin path
   command: "cp {{ consul_download_folder }}/consul-cli-master/bin/consul-cli {{ consul_home }}/bin/"
   args:
     creates: "{{ consul_home }}/bin/consul-cli"
+  when: cli_download.changed
 
 - name: set consul-cli permissions
   file:
@@ -35,3 +41,4 @@
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
     mode: "0755"
+  when: cli_download.changed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,6 +40,7 @@
   group: >
     name={{consul_group}}
     state=present
+    system=yes
   register: consul_group_created
 
 - name: create consul user

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -198,6 +198,6 @@
     insertbefore=BOF 
     regexp='^export CONSUL_RPC_ADDR' 
     line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"' 
-    create= yes
-    become= yes
+    create=yes
+    become=yes
     become_user={{ consul_user }}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -193,4 +193,11 @@
     - restart consul
 
 - name: add CONSUL_RPC_ADDR to .bashrc
-  lineinfile: dest="{{ consul_home }}/.bashrc" insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"' create=yes
+  lineinfile: >
+    dest={{ consul_home }}/.bashrc
+    insertbefore=BOF 
+    regexp='^export CONSUL_RPC_ADDR' 
+    line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"' 
+    create= yes
+    become= yes
+    become_user={{ consul_user }}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -141,7 +141,7 @@
     mode=0644
   when: consul_use_upstart and ansible_os_family == "Debian"
   notify:
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: copy consul systemd script
   template: >
@@ -153,7 +153,7 @@
   when: consul_use_systemd
   notify:
     - reload systemd
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: copy consul init.d script
   template: >
@@ -164,7 +164,7 @@
     mode=0755
   when: consul_use_initd
   notify:
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: add consul to path through profile.d
   template: >
@@ -190,7 +190,7 @@
     group={{consul_group}}
     mode=0755
   notify:
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: add CONSUL_RPC_ADDR to .bashrc
   lineinfile: >

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -2,3 +2,4 @@
     name=consul
     state="{{ consul_service_state }}"
     enabled=yes
+  when: consul_manage_service

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -30,6 +30,10 @@ sudo setcap CAP_NET_BIND_SERVICE=+eip {{ consul_home }}/bin/consul; exec sudo -u
   >> {{ consul_log_file }} 2>&1
 end script
 
+{% if consul_leave_on_terminate -%}
+pre-stop exec {{ consul_home }}/bin/consul leave
+{% endif -%}
+
 respawn
 respawn limit 10 10
 

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -146,6 +146,9 @@
         "Access-Control-Allow-Origin": "*"
   },
 {% endif %}
+{% if consul_skip_leave_on_interrupt is defined %}
+  "skip_leave_on_interrupt": {{ "true" if consul_skip_leave_on_interrupt else "false" }},
+{% endif %}
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
   "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }}
 }

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -150,5 +150,7 @@
   "skip_leave_on_interrupt": {{ "true" if consul_skip_leave_on_interrupt else "false" }},
 {% endif %}
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
-  "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }}
+  "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }},
+  "disable_update_check": {{ "true" if consul_disable_update_check else "false" }}
+
 }

--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -8,7 +8,7 @@ Environment="GOMAXPROCS=`nproc`"
 Restart=on-failure
 User={{ consul_user }}
 Group={{ consul_group }}
-ExecStart=/bin/sh -c '{{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}'
+ExecStart={{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 

--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -8,7 +8,7 @@ Environment="GOMAXPROCS=`nproc`"
 Restart=on-failure
 User={{ consul_user }}
 Group={{ consul_group }}
-ExecStart=/bin/sh -c '{{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }} >> {{ consul_log_file }} 2>&1'
+ExecStart=/bin/sh -c '{{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}'
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 


### PR DESCRIPTION
I believe ansible runs handlers in the order they're defined in the `handlers/main.yml`, and the systemd reload should happen before the consul restart. 