### PR TITLE
On stop service [upstart], send TERM sig

### DIFF
--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -30,8 +30,11 @@ sudo setcap CAP_NET_BIND_SERVICE=+eip {{ consul_home }}/bin/consul; exec sudo -u
   >> {{ consul_log_file }} 2>&1
 end script
 
+{% if consul_leave_on_terminate -%}
+pre-stop exec {{ consul_home }}/bin/consul leave
+{% endif -%}
+
 respawn
 respawn limit 10 10
 
 kill timeout 10
-kill signal TERM

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -34,3 +34,4 @@ respawn
 respawn limit 10 10
 
 kill timeout 10
+kill signal TERM


### PR DESCRIPTION
After some tinkering, it seems as though on service stop - if you have ```consul_leave_on_terminate``` set to true, this is ignored as the ```service consul stop``` command sends signal 1, not TERM like consul expects for that config to work.

Additionally, if you attempt to do a ```consul leave```, the agent dies and then upstart attempts to kick it on again, which causes it to rejoin the cluster.  This is not desired (afaik).  This pull request doesnt fix that, however it does allow you to just stop the service and have it leave the cluster cleanly.

I've tested both cases - with ```consul_leave_on_terminate```  on and off.  The behavior seems to work as intended now.  However I'm not sure of the downstream impacts of this so could use your input if you have any.