### PR TITLE
Instead of sudo/sudo_user, use become/become_user and make sure

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,12 +4,12 @@
   when: consul_manage_service
 
 - name: reload consul config
-  sudo: yes
+  become: yes
   command: pkill -1 consul
   when: consul_service_state is not "stopped" and consul_manage_service
 
 - name: reload systemd
-  sudo: yes
+  become: yes
   command: systemctl daemon-reload
 
 - name: restart dnsmasq


### PR DESCRIPTION
become_method is 'sudo' (default). This feature will be removed in a
future release.