### PR TITLE
Adopted role for use without systemd and upstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,25 @@ These are the handlers that are defined in `handlers/main.yml`.
     - ansible-consul
 ```
 
+## Example playbook that configures a Consul server on Ubuntu with [runit](https://github.com/gitinsky/ansible-role-runit)
+```yml
+- hosts: all
+  vars:
+    consul_reload_config_handler: runit reload consul
+    consul_restart_handler: runit restart consul
+    consul_log_file: /dev/null
+  roles:
+    - ansible-consul
+    - role: runit
+      runit_pre_start_command: "setcap CAP_NET_BIND_SERVICE=+eip /opt/consul/bin/consul"
+      runit_service_command: "/opt/consul/bin/consul"
+      runit_service_params: "agent -config-dir /etc/consul.d -config-file=/etc/consul.conf"
+      runit_service_env:
+        GOMAXPROCS: "{{ ansible_processor_vcpus }}"
+```
+
+Logs will be handled by runit and ```consul_log_file``` set to ```/dev/null``` just to prevent ```/var/log/consul``` file creation as it conflicts with runit logs directory.
+
 ## Example playbooks that configures a Consul server on CentOS 7
 
 ```yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,9 @@ consul_kv_template: "consulkv.j2"
 consul_add_path_template: "consul.sh.j2"
 consul_config_template: "consul.json.j2"
 
+consul_reload_config_handler: reload consul config
+consul_restart_handler: restart consul
+
 consul_binary: consul
 
 consul_user: consul

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -140,7 +140,7 @@
     mode=0644
   when: consul_use_upstart and ansible_os_family == "Debian"
   notify:
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: copy consul systemd script
   template: >
@@ -152,7 +152,7 @@
   when: consul_use_systemd
   notify:
     - reload systemd
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: copy consul init.d script
   template: >
@@ -163,7 +163,7 @@
     mode=0755
   when: consul_use_initd
   notify:
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: add consul to path through profile.d
   template: >
@@ -189,7 +189,7 @@
     group={{consul_group}}
     mode=0755
   notify:
-    - restart consul
+    - "{{ consul_restart_handler }}"
 
 - name: add CONSUL_RPC_ADDR to .bashrc
   lineinfile: dest="{{ consul_home }}/.bashrc" insertbefore=BOF regexp='^export CONSUL_RPC_ADDR' line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"' create=yes

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -2,3 +2,4 @@
     name=consul
     state="{{ consul_service_state }}"
     enabled=yes
+  when: consul_manage_service


### PR DESCRIPTION
I can't accept the way upstart is used in this role, I got 1TB of logs during the weekend. So I've moved to [runit](https://github.com/gitinsky/ansible-role-runit) and fixed handler issues.

Here're the variables:
```yml
runit_pre_start_command: "setcap CAP_NET_BIND_SERVICE=+eip /opt/consul/bin/consul"
runit_service_command: "/opt/consul/bin/consul"
runit_service_params: "agent -config-dir /etc/consul.d -config-file=/etc/consul.conf"
runit_service_env:
   GOMAXPROCS: "{{ ansible_processor_vcpus }}"

consul_reload_config_handler: runit reload consul
consul_restart_handler: runit restart consul
```
