### PR TITLE
Make consul group a system group

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,6 +40,7 @@
   group: >
     name={{consul_group}}
     state=present
+    system=yes
   register: consul_group_created
 
 - name: create consul user


### PR DESCRIPTION
Since `consul_user` is a system user, I would assume `consul_group` should also be a system group in order to avoid a collision with non-system GIDs.