### PR TITLE
Improve service status handling and systemd support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ consul_ui_server_port: 80
 consul_install_nginx: true
 consul_install_nginx_config: true
 consul_enable_nginx_config: true
-consul_service_state: restarted
+consul_service_state: started
 consul_manage_service: true
 
 consul_install_consul_cli: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart consul
-  action: service name=consul state={{ consul_service_state }} enabled=yes
+  action: service name=consul state=restarted enabled=yes
   when: consul_manage_service
 
 - name: reload consul config

--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -8,7 +8,7 @@ Environment="GOMAXPROCS=`nproc`"
 Restart=on-failure
 User={{ consul_user }}
 Group={{ consul_group }}
-ExecStart=/bin/sh -c '{{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}'
+ExecStart={{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 


### PR DESCRIPTION
This PR covers 2 things:

* The service state should be set to the value of the `consul_service_state` variable, but the "_restart consul_" handler should always be `restarted`.
* _systemd_ logs are collected via journald, so the _systemd_ unit shouldn't explicitly forward logs to a file (removing `sh -c` also prevents the service from forking)