### PR TITLE
Added consul_skip_leave_on_interrupt variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ Consul allows adding headers to the HTTP API responses, to enable [CORS](https:/
 ```yml
 consul_cors_support: true
 ```
+## Shutdown behavior
+Consul may be configured to perform (or not) cluster leave when it recieves TERM/INT signals.
+
+When service is stopped:
+ * systemd sends INT
+ * init (init.d script) sends TERM
+ * upstart sends TERM
+
+There are two variables that define if the node will attempt cluster leave when it recieves those signals:
+
+ * `consul_leave_on_terminate` defines if leave is performed when TERM is recieved. default: `false`
+ * `consul_skip_leave_on_interrupt` defines if leave is **not** performed when INT is recieved. default: `undefined`. If this variable is not defined default consul behavior (which depends on version and server/agent role) will be used.
 
 ## Handlers
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,3 +112,5 @@ consul_node_name: "{{ inventory_hostname }}"
 # Set to true to enable hostname verification via TLS
 consul_verify_server_hostname: false
 consul_cors_support: false
+# keep undefined for default behavior (will depend on agent/server role starting with consul 0.7)
+# consul_skip_leave_on_interrupt: false

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -148,4 +148,7 @@
 {% endif %}
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
   "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }}
+{% if consul_skip_leave_on_interrupt is defined %}
+  "skip_leave_on_interrupt": {{ "true" if consul_skip_leave_on_interrupt else "false" }}
+{% endif %}
 }

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -146,9 +146,9 @@
         "Access-Control-Allow-Origin": "*"
   },
 {% endif %}
+{% if consul_skip_leave_on_interrupt is defined %}
+  "skip_leave_on_interrupt": {{ "true" if consul_skip_leave_on_interrupt else "false" }},
+{% endif %}
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
   "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }}
-{% if consul_skip_leave_on_interrupt is defined %}
-  "skip_leave_on_interrupt": {{ "true" if consul_skip_leave_on_interrupt else "false" }}
-{% endif %}
 }


### PR DESCRIPTION
This variable controls whether consul agent/server will leave cluster when it receives SIGINT.