### PR TITLE
Fix disable_update_check default variable name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -117,4 +117,4 @@ consul_verify_server_hostname: false
 consul_cors_support: false
 # keep undefined for default behavior (will depend on agent/server role starting with consul 0.7)
 # consul_skip_leave_on_interrupt: false
-disable_update_check: false
+consul_disable_update_check: false


### PR DESCRIPTION
The default variable name for disable_update_check setting is incorrect and it causes the following error when running the playbook: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'consul_disable_update_check' is undefined"}. It should be consul_disable_update_check instead of disable_update_check in defaults/main.yml