### PR TITLE
Reorder handlers so systemd config is reloaded before consul restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: reload systemd
+  become: yes
+  command: systemctl daemon-reload
+
 - name: restart consul
   action: service name=consul state=restarted enabled=yes
   when: consul_manage_service
@@ -7,10 +11,6 @@
   become: yes
   command: pkill -1 consul
   when: consul_service_state is not "stopped" and consul_manage_service
-
-- name: reload systemd
-  become: yes
-  command: systemctl daemon-reload
 
 - name: restart dnsmasq
   service: name=dnsmasq state=restarted enabled=yes


### PR DESCRIPTION
Continuation of #133 but rebased to latest master. 