### PR TITLE
sudo and set file ownership explicitely

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -199,5 +199,6 @@
     regexp='^export CONSUL_RPC_ADDR' 
     line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"' 
     create=yes
-    become=yes
-    become_user={{ consul_user }}
+    owner={{consul_user}}
+    group={{consul_group}}
+  become: yes


### PR DESCRIPTION
As of ansible 2.1, using an unprivileged user (`become` and
`become_user`) creates an exception since it does not want to create
the temp file for the command with world writeable permissions (see
https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-us
er for more details). There are many solutions, however just sudo and
set the permissions does the trick.

Fixes savagegus/ansible-consul#146