### PR TITLE
Become/become_user on wrong lines of ansible task

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -193,11 +193,11 @@
     - "{{ consul_restart_handler }}"
 
 - name: add CONSUL_RPC_ADDR to .bashrc
+  become: yes
+  become_user: "{{ consul_user }}"
   lineinfile: >
     dest={{ consul_home }}/.bashrc
     insertbefore=BOF 
     regexp='^export CONSUL_RPC_ADDR' 
     line='export CONSUL_RPC_ADDR="{{ consul_client_address }}:{{ consul_port_rpc }}"' 
     create=yes
-    become=yes
-    become_user={{ consul_user }}


### PR DESCRIPTION
Ansible 2.1.0.0 did not like task `- name: add CONSUL_RPC_ADDR to .bashrc` in `tasks/install.yml` because of:
```
become: yes
become_user: "{{ consul_user }}"
```
This PR moves the two commands out of `lineinfile` and into the task definition.