### PR TITLE
Add consul services support

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,22 @@ Logs will be handled by runit and ```consul_log_file``` set to ```/dev/null``` j
     - ansible-consul
 ```
 
+## Example to register consul services
+
+```yml
+consul_services:
+  - service:
+      name: "redis localhost"
+      tags:
+        - "redis"
+      address: "127.0.0.1"
+      port: 6379
+      checks:
+        - name: "Redis health check"
+          tcp: "localhost:6379"
+          interval: "10s"
+          timeout: "1s"
+```
 
 ## Testing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -118,3 +118,7 @@ consul_cors_support: false
 # keep undefined for default behavior (will depend on agent/server role starting with consul 0.7)
 # consul_skip_leave_on_interrupt: false
 consul_disable_update_check: false
+
+# Define Consul services to add to /etc/consul.d/*
+consul_services: {}
+consul_services_mode: 0640

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,4 +4,9 @@
 - { include: install-cli.yml, when: consul_install_consul_cli == true }
 - { include: dnsmasq.yml, when: consul_install_dnsmasq == true }
 - { include: consulate.yml, when: consul_install_consulate == true }
-- include: service.yml
+- service: >
+    name=consul
+    state="{{ consul_service_state }}"
+    enabled=yes
+  when: consul_manage_service
+- { include: services.yml, when: consul_services is defined and consul_services|length > 0 }

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,5 +1,0 @@
-- service: >
-    name=consul
-    state="{{ consul_service_state }}"
-    enabled=yes
-  when: consul_manage_service

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,10 @@
+---
+- name: 'Installing consul services to {{ consul_config_dir }}'
+  copy:
+    dest: '{{ consul_config_dir }}/{{ item.service.name.split() | join("_") }}_{{ item.service.port }}.json'
+    owner: '{{ consul_user }}'
+    group: '{{ consul_group }}'
+    mode: '{{ consul_services_mode }}'
+    content: '{{ item | to_json }}'
+  with_items: '{{ consul_services }}'
+  notify: restart consul


### PR DESCRIPTION
@savagegus @robbiet480 @benjaminws @msabramo 

This adds support for consul services 

https://www.consul.io/docs/agent/services.html

I am aware of python-consul module (http://docs.ansible.com/ansible/consul_module.html) with ansible version 2.1 it contains bug furthermore requires pip and module above.

