### PR TITLE
Allow config file mode to be changed, e.g. to non-world readable if i…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ consul_cli_download: "https://github.com/CiscoCloud/consul-cli/archive/{{ consul
 consul_home: /opt/consul
 consul_config_dir: /etc/consul.d
 consul_config_file: /etc/consul.conf
+# World readable for backward compatibility; set to 0600 if using consul_encrypt_key
+consul_config_file_mode: 0644
 consul_log_file: /var/log/consul
 consul_data_dir: "{{ consul_home }}/data"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,10 @@ consul_use_systemd: false
 consul_use_upstart: true
 consul_use_initd: false
 
+# Upstart start/stop conditions can vary by distribution and environment
+consul_upstart_start_on: start on runlevel [345]
+consul_upstart_stop_on: stop on runlevel [!345]
+
 consul_is_server: false
 
 consul_domain: consul.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -195,7 +195,7 @@
     dest={{ consul_config_file }}
     owner={{consul_user}}
     group={{consul_group}}
-    mode=0755
+    mode={{consul_config_file_mode}}
   notify:
     - "{{ consul_restart_handler }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_os_family }}.yml"
 - include: install.yml
 - { include: install-ui.yml, when: consul_is_ui == true }
 - { include: install-cli.yml, when: consul_install_consul_cli == true }

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -1,8 +1,8 @@
 # Consul Agent (Upstart unit)
 description "Consul Agent"
 
-start on (local-filesystems and net-device-up IFACE!=lo)
-stop on runlevel [016]
+start on {{ consul_upstart_start_on }}
+stop on {{ consul_upstart_stop_on }}
 
 script
 {% if consul_dynamic_bind %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+consul_upstart_start_on: (local-filesystems and net-device-up IFACE!=lo)
+consul_upstart_stop_on: runlevel [016]

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+consul_upstart_start_on: (runlevel [345] and started network)
+consul_upstart_stop_on: (runlevel [!345] or stopping network)


### PR DESCRIPTION
…t contains a gossip encryption key

The previous mode was 0755, which I'm assuming was unintentional. The new default is 0644 (not executable) for backward compatibility, but can be changed to 0600 if the file contains secrets.
