### PR TITLE
Make Upstart start/stop conditions configurable and fix RedHat values

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,10 @@ consul_use_systemd: false
 consul_use_upstart: true
 consul_use_initd: false
 
+# Upstart start/stop conditions can vary by distribution and environment
+consul_upstart_start_on: start on runlevel [345]
+consul_upstart_stop_on: stop on runlevel [!345]
+
 consul_is_server: false
 
 consul_domain: consul.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_os_family }}.yml"
 - include: install.yml
 - { include: install-ui.yml, when: consul_is_ui == true }
 - { include: install-cli.yml, when: consul_install_consul_cli == true }

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -1,8 +1,8 @@
 # Consul Agent (Upstart unit)
 description "Consul Agent"
 
-start on (local-filesystems and net-device-up IFACE!=lo)
-stop on runlevel [016]
+start on {{ consul_upstart_start_on }}
+stop on {{ consul_upstart_stop_on }}
 
 script
 {% if consul_dynamic_bind %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+consul_upstart_start_on: (local-filesystems and net-device-up IFACE!=lo)
+consul_upstart_stop_on: runlevel [016]

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+consul_upstart_start_on: (runlevel [345] and started network)
+consul_upstart_stop_on: (runlevel [!345] or stopping network)


### PR DESCRIPTION
The Debian condition for Upstart "start on" was not working for RHEL/CentOS 6 (Consul would not start at boot). It is difficult to tell specifically why not because the Upstart version is so old, but the conditions recommended [here](http://serverfault.com/a/643953/76832) seem to work. The prior values are retained for Debian systems.
