### PR TITLE
install-ui: Fix selinux task error on Debian

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -78,4 +78,4 @@
 
 - name: allow nginx to connect to consul (selinux)
   seboolean: name=httpd_can_network_connect state=yes persistent=yes
-  when: consul_is_ui and consul_install_nginx_config and ansible_selinux.status == "enabled"
+  when: consul_is_ui and consul_install_nginx_config and ansible_os_family == "RedHat" and ansible_selinux.status == "enabled"


### PR DESCRIPTION
Error on Debian:

```TASK [savagegus.consul : allow nginx to connect to consul (selinux)] ***********
fatal: [ip]: FAILED! => {"changed": false, "failed": true, "msg": "This module requires libselinux-python support"}```