### PR TITLE
additional check to prevent error while checking ansible_selinux.status

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -78,4 +78,4 @@
 
 - name: allow nginx to connect to consul (selinux)
   seboolean: name=httpd_can_network_connect state=yes persistent=yes
-  when: consul_is_ui and consul_install_nginx_config and ansible_selinux.status == "enabled"
+  when: consul_is_ui and consul_install_nginx_config and ansible_selinux is defined and ansible_selinux.status == 'enabled'


### PR DESCRIPTION
Got error on Ubuntu 16.10:

> FAILED! => {
>     "failed": true,
>     "msg": "The conditional check 'consul_is_ui and consul_install_nginx_config and ansible_selinux.status == \"enabled\"' failed. The error was: error while evaluating conditional (consul_is_ui and consul_install_nginx_config and ansible_selinux.status == \"enabled\"): 'bool object' has no attribute 'status'\n\nThe error appears to have been in '/home/suvitruf/ansible/roles/consul/tasks/install-ui.yml': line 79, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: allow nginx to connect to consul (selinux)\n  ^ here\n"

Aditional check `ansible_selinux is defined` prevents it.
