### PR TITLE
Fix CentOS 7 example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,9 @@ Logs will be handled by runit and ```consul_log_file``` set to ```/dev/null``` j
     consul_datacenter: "test"
     consul_bootstrap: "true"
     consul_bind_address: "{{ ansible_default_ipv4['address'] }}"
+    consul_use_upstart: false
     consul_use_systemd: true
+    nginx_user: "nginx"
   roles:
     - ansible-consul
 ```


### PR DESCRIPTION
For CentOS 7 I encountered the following issues:
* Upstart needs to be disabled
* nginx user is not `www-data`

As there is only upstart and systemd to choose from maybe it makes more sense to put this in a single boolean.

This pull request just fixes the example from the README to be a working example. (tested with vagrant and the included `test.yml` file)