### PR TITLE
Add BIND capabilities for consul on systemd

### DIFF
--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -8,6 +8,8 @@ Environment="GOMAXPROCS=`nproc`"
 Restart=on-failure
 User={{ consul_user }}
 Group={{ consul_group }}
+PermissionsStartOnly=true
+ExecStartPre=/sbin/setcap CAP_NET_BIND_SERVICE=+eip /opt/consul/bin/consul
 ExecStart={{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT

--- a/templates/consul.systemd.j2
+++ b/templates/consul.systemd.j2
@@ -9,7 +9,7 @@ Restart=on-failure
 User={{ consul_user }}
 Group={{ consul_group }}
 PermissionsStartOnly=true
-ExecStartPre=/sbin/setcap CAP_NET_BIND_SERVICE=+eip /opt/consul/bin/consul
+ExecStartPre=/sbin/setcap CAP_NET_BIND_SERVICE=+eip {{ consul_home }}/bin/consul
 ExecStart={{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT


### PR DESCRIPTION
Without this change, running consul on systemd with non-root user would fail with:

```
# sudo -u consul -g consul /opt/consul/bin/consul agent -config-dir /etc/consul.d -config-file=/etc/consul.conf
==> Starting Consul agent...
==> Starting Consul agent RPC...
==> Error starting dns server: dns udp setup failed: listen udp 0.0.0.0:53: bind: permission denied
```